### PR TITLE
provide current-time value

### DIFF
--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -138,9 +138,7 @@ class Telemetry(object):
         """ Checks if USB device is busy """
 
         usb_path = '/dev/bus/usb/{0}/{1}'.format(bus_id, device_id)
-        logging.info('start usb busy: {}'.format(usb_path))
         return_code = nb.shell_execute(['/usr/bin/lsof', usb_path])['returncode']
-        logging.info('end usb busy: {} {}'.format(usb_path, return_code))
         return return_code == 0
 
     def get_usb_devices(self):
@@ -207,18 +205,13 @@ class Telemetry(object):
     def update_status(self, current_time):
         """ Runs a cycle of the categorization, to update the NuvlaBox status """
 
-        logging.info('telemetry before status')
         new_status = self.get_status()
-        logging.info('telemetry after status')
         updated_status, delete_attributes = self.diff(self.status, new_status)
-        logging.info('telemetry after diff')
         updated_status['current-time'] = current_time.isoformat().split('.')[0] + 'Z'
-        logging.info('telemetry after time')
         updated_status['id'] = self.nb_status_id
         logging.info('Refresh status: %s' % updated_status)
         self.api._cimi_put(self.nb_status_id,
                            json=updated_status)  # should also include ", select=delete_attributes)" but CIMI does not allow
-        logging.info('telemetry status update')
         self.status = new_status
 
     def update_operational_status(self, status="RUNNING", status_log=None):

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -191,12 +191,12 @@ class Telemetry(object):
                 minimal_update[key] = new_status[key]
         return minimal_update, delete_attributes
 
-    def update_status(self, next_check):
+    def update_status(self, current_time):
         """ Runs a cycle of the categorization, to update the NuvlaBox status """
 
         new_status = self.get_status()
         updated_status, delete_attributes = self.diff(self.status, new_status)
-        updated_status['next-heartbeat'] = next_check.isoformat().split('.')[0] + 'Z'
+        updated_status['current-time'] = current_time.isoformat().split('.')[0] + 'Z'
         updated_status['id'] = self.nb_status_id
         logging.info('Refresh status: %s' % updated_status)
         self.api._cimi_put(self.nb_status_id,

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -7,6 +7,7 @@ It takes care of updating the NuvlaBox status
 resource in Nuvla.
 """
 
+import datetime
 import docker
 import logging
 import multiprocessing
@@ -195,12 +196,12 @@ class Telemetry(object):
                 minimal_update[key] = new_status[key]
         return minimal_update, delete_attributes
 
-    def update_status(self, current_time):
+    def update_status(self):
         """ Runs a cycle of the categorization, to update the NuvlaBox status """
 
         new_status = self.get_status()
         updated_status, delete_attributes = self.diff(self.status, new_status)
-        updated_status['current-time'] = current_time.isoformat().split('.')[0] + 'Z'
+        updated_status['current-time'] = datetime.datetime.utcnow().isoformat().split('.')[0] + 'Z'
         updated_status['id'] = self.nb_status_id
         logging.info('Refresh status: %s' % updated_status)
         self.api._cimi_put(self.nb_status_id,

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -49,17 +49,11 @@ class Telemetry(object):
     def get_status(self):
         """ Gets several types of information to populate the NuvlaBox status """
 
-        logging.info('get_status')
         cpu_info = self.get_cpu()
-        logging.info('after get_cpu')
         ram_info = self.get_ram()
-        logging.info('after get_ram')
         disk_usage = self.get_disks_usage()
-        logging.info('after get_disks_usage')
         usb_devices = self.get_usb_devices()
-        logging.info('after get_usb_devices')
         operational_status = nb.get_operational_status(self.data_volume)
-        logging.info('after get_operational_status')
 
         return {
             'resources': {
@@ -145,7 +139,6 @@ class Telemetry(object):
         """ Looks up list of USB devices """
 
         usb_devices_line = nb.shell_execute(['/usr/bin/lsusb'])['stdout'].decode("utf-8").splitlines()
-        logging.info('after lsusb')
         usb_devices = []
         for usb_device in usb_devices_line:
             usb_info = usb_device.split()

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -138,13 +138,16 @@ class Telemetry(object):
         """ Checks if USB device is busy """
 
         usb_path = '/dev/bus/usb/{0}/{1}'.format(bus_id, device_id)
+        logging.info('start usb busy: {}'.format(usb_path))
         return_code = nb.shell_execute(['/usr/bin/lsof', usb_path])['returncode']
+        logging.info('end usb busy: {} {}'.format(usb_path, return_code))
         return return_code == 0
 
     def get_usb_devices(self):
         """ Looks up list of USB devices """
 
         usb_devices_line = nb.shell_execute(['/usr/bin/lsusb'])['stdout'].decode("utf-8").splitlines()
+        logging.info('after lsusb')
         usb_devices = []
         for usb_device in usb_devices_line:
             usb_info = usb_device.split()

--- a/code/app.py
+++ b/code/app.py
@@ -16,7 +16,6 @@ Arguments:
 """
 
 import socket
-import datetime
 import threading
 from flask import Flask, request
 from agent.common import nuvlabox as nb
@@ -107,8 +106,7 @@ if __name__ == "__main__":
             nuvlabox_info_updated_date = nuvlabox_resource['updated']
             nb.create_context_file(nuvlabox_resource, telemetry.data_volume)
 
-        current_time = datetime.datetime.utcnow()
-        telemetry.update_status(current_time)
+        telemetry.update_status()
 
         infra.try_commission()
         e.wait(timeout=refresh_interval/2)

--- a/code/app.py
+++ b/code/app.py
@@ -107,8 +107,8 @@ if __name__ == "__main__":
             nuvlabox_info_updated_date = nuvlabox_resource['updated']
             nb.create_context_file(nuvlabox_resource, telemetry.data_volume)
 
-        next_check = datetime.datetime.utcnow() + datetime.timedelta(seconds=refresh_interval)
-        telemetry.update_status(next_check)
+        current_time = datetime.datetime.utcnow()
+        telemetry.update_status(current_time)
 
         infra.try_commission()
         e.wait(timeout=refresh_interval/2)

--- a/code/app.py
+++ b/code/app.py
@@ -100,23 +100,15 @@ if __name__ == "__main__":
     monitoring_thread.start()
 
     while True:
-        logging.info('beginning of agent loop')
         nuvlabox_resource = nb.get_nuvlabox_info(telemetry.api)
-        logging.info('got nuvlabox resource')
         if nuvlabox_info_updated_date != nuvlabox_resource['updated']:
-            logging.info('nuvlabox resource update')
             refresh_interval = nuvlabox_resource['refresh-interval']
             logging.warning('NuvlaBox resource updated. Refresh interval value: {}s'.format(refresh_interval))
             nuvlabox_info_updated_date = nuvlabox_resource['updated']
             nb.create_context_file(nuvlabox_resource, telemetry.data_volume)
-            logging.info('end nuvlabox resource update')
 
         current_time = datetime.datetime.utcnow()
-        logging.info('before status')
         telemetry.update_status(current_time)
-        logging.info('after status')
 
-        logging.info('before commission')
         infra.try_commission()
-        logging.info('after commission')
         e.wait(timeout=refresh_interval/2)

--- a/code/app.py
+++ b/code/app.py
@@ -100,15 +100,23 @@ if __name__ == "__main__":
     monitoring_thread.start()
 
     while True:
+        logging.info('beginning of agent loop')
         nuvlabox_resource = nb.get_nuvlabox_info(telemetry.api)
+        logging.info('got nuvlabox resource')
         if nuvlabox_info_updated_date != nuvlabox_resource['updated']:
+            logging.info('nuvlabox resource update')
             refresh_interval = nuvlabox_resource['refresh-interval']
             logging.warning('NuvlaBox resource updated. Refresh interval value: {}s'.format(refresh_interval))
             nuvlabox_info_updated_date = nuvlabox_resource['updated']
             nb.create_context_file(nuvlabox_resource, telemetry.data_volume)
+            logging.info('end nuvlabox resource update')
 
         current_time = datetime.datetime.utcnow()
+        logging.info('before status')
         telemetry.update_status(current_time)
+        logging.info('after status')
 
+        logging.info('before commission')
         infra.try_commission()
+        logging.info('after commission')
         e.wait(timeout=refresh_interval/2)


### PR DESCRIPTION
Provide a `current-time` value in the nuvlabox-status to allow clock skew to be detected. Remove the update of the `next-heartbeat` field as this is now handled by the server.