### PR TITLE
Add temperature metrics

### DIFF
--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -564,7 +564,6 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
 
         return status_for_nuvla, all_status
 
-    @staticmethod
     def get_temperature(self):
         """ Attempts to retrieve temperature information, if it exists. The keys will vary depending on the
         underlying host system.
@@ -589,16 +588,16 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
                     logging.warning(f'Thermal zone (at {thermal_zone_file}) and temperature (at {temperature_file}) values do not complement each other')
                     continue
 
-                with open(thermal_zone_file) as t:
+                with open(thermal_zone_file) as tzf:
                     try:
-                        metric_basename = t.read().split()[0]
+                        metric_basename = tzf.read().split()[0]
                     except:
                         logging.warning(f'Cannot read thermal zone at {thermal_zone_file}')
                         continue
                 
-                with open(temperature_file) as t:
+                with open(temperature_file) as tf:
                     try:
-                        temperature_value = t.read().split()[0]
+                        temperature_value = tf.read().split()[0]
                     except:
                         logging.warning(f'Cannot read temperature at {temperature_file}')
                         continue
@@ -609,8 +608,8 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
 
                 try:
                     output[metric_basename] = float(temperature_value)/1000
-                except ValueError:
-                    logging.warning(f'Cannot convert temperature at {temperature_file}')
+                except (ValueError, TypeError) as e:
+                    logging.warning(f'Cannot convert temperature at {temperature_file}. Reason: {str(e)}')
 
         return output
 

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -116,14 +116,13 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
         # Default to 1 hour
         self.time_between_get_geolocation = 3600
 
-    def send_mqtt(self, nuvlabox_status, cpu=None, ram=None, disks=None, temperature=None, energy=None):
+    def send_mqtt(self, nuvlabox_status, cpu=None, ram=None, disks=None, energy=None):
         """ Gets the telemetry data and send the stats into the MQTT broker
 
         :param nuvlabox_status: full dump of the NB status {}
         :param cpu: tuple (capacity, load)
         :param ram: tuple (capacity, used)
         :param disk: list of {device: partition_name, capacity: value, used: value}
-        :param temperature: {thermal_zone: value}
         :param energy: energy consumption metric
         """
 
@@ -168,11 +167,6 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
                 os.system("mosquitto_pub -h {} -t {} -m '{}'".format(self.mqtt_broker_host,
                                                                      "disks",
                                                                      json.dumps(dsk)))
-
-        if temperature:
-            os.system("mosquitto_pub -h {} -t {} -m '{}'".format(self.mqtt_broker_host,
-                                                                 "temperature",
-                                                                 json.dumps(temperature)))
                                                                  
         if energy:
             # self.mqtt_telemetry.publish("ram/capacity", payload=str(ram[0]))

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -167,7 +167,7 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
                 os.system("mosquitto_pub -h {} -t {} -m '{}'".format(self.mqtt_broker_host,
                                                                      "disks",
                                                                      json.dumps(dsk)))
-                                                                 
+
         if energy:
             # self.mqtt_telemetry.publish("ram/capacity", payload=str(ram[0]))
             # self.mqtt_telemetry.publish("ram/used", payload=str(ram[1]))
@@ -176,8 +176,6 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
                                                                  "energy",
                                                                  json.dumps(energy)))
                 
-        
-
         # self.mqtt_telemetry.disconnect()
 
     def get_installation_parameters(self):
@@ -406,7 +404,7 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
             status_for_nuvla['nuvlabox-engine-version'] = self.nuvlabox_engine_version
 
         # Publish the telemetry into the Data Gateway
-        self.send_mqtt(status_for_nuvla, cpu_sample, ram_sample, disk_usage, temperature)
+        self.send_mqtt(status_for_nuvla, cpu_sample, ram_sample, disk_usage)
 
         # get all status for internal monitoring
         all_status = status_for_nuvla.copy()

--- a/code/agent/Telemetry.py
+++ b/code/agent/Telemetry.py
@@ -564,6 +564,7 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
 
         return status_for_nuvla, all_status
 
+    @staticmethod
     def get_temperature(self):
         """ Attempts to retrieve temperature information, if it exists. The keys will vary depending on the
         underlying host system.
@@ -575,15 +576,41 @@ class Telemetry(NuvlaBoxCommon.NuvlaBoxCommon):
 
         output = {}
 
-        command_thermal_zone = "cat /sys/devices/virtual/thermal/thermal_zone*/type"
-        command_temperatures = "cat /sys/devices/virtual/thermal/thermal_zone*/temp"
-        r_thermal_zone = run(command_thermal_zone, stdout=PIPE, stderr=STDOUT, encoding='UTF-8', shell=True)
-        r_temperatures = run(command_temperatures, stdout=PIPE, stderr=STDOUT, encoding='UTF-8', shell=True)
+        thermal_fs_path = f'{self.hostfs}/sys/devices/virtual/thermal'
 
-        temperatures_list = r_temperatures.stdout.split()
-        thermal_zone_list = r_thermal_zone.stdout.split()
+        if not os.path.exists(thermal_fs_path):
+            return psutil.sensors_temperatures()
 
-        output = {thermal_zone_list[i]: float(temperatures_list[i])/1000 for i in range(len(thermal_zone_list))}
+        for subdirs in os.listdir(thermal_fs_path):
+            if subdirs.startswith("thermal"):
+                thermal_zone_file = f'{thermal_fs_path}/{subdirs}/type'
+                temperature_file = f'{thermal_fs_path}/{subdirs}/temp'
+                if not os.path.exists(thermal_zone_file) or not os.path.exists(temperature_file):
+                    logging.warning(f'Thermal zone (at {thermal_zone_file}) and temperature (at {temperature_file}) values do not complement each other')
+                    continue
+
+                with open(thermal_zone_file) as t:
+                    try:
+                        metric_basename = t.read().split()[0]
+                    except:
+                        logging.warning(f'Cannot read thermal zone at {thermal_zone_file}')
+                        continue
+                
+                with open(temperature_file) as t:
+                    try:
+                        temperature_value = t.read().split()[0]
+                    except:
+                        logging.warning(f'Cannot read temperature at {temperature_file}')
+                        continue
+
+                if not metric_basename or not temperature_value:
+                    logging.warning(f'Thermal zone {thermal_zone_file} or temperature {temperature_file} value is missing')
+                    continue
+
+                try:
+                    output[metric_basename] = float(temperature_value)/1000
+                except ValueError:
+                    logging.warning(f'Cannot convert temperature at {temperature_file}')
 
         return output
 


### PR DESCRIPTION
Temperature metrics added. 
The values are read from **/sys/devices/virtual/thermal_zone\*/temp** and returns a dictionary like:
 { \<Thermal Zone\> : \<Temperature value (in degrees Celsius)\>, ...}. 
If the returned object is empty, psutil.sensors_temperatures() is executed (check https://psutil.readthedocs.io/en/latest/#psutil.sensors_temperatures).